### PR TITLE
Initialize FairyTaleKids React Native TypeScript app

### DIFF
--- a/FairyTaleKids/app.json
+++ b/FairyTaleKids/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "FairyTaleKids",
+  "displayName": "FairyTaleKids"
+}

--- a/FairyTaleKids/babel.config.js
+++ b/FairyTaleKids/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};

--- a/FairyTaleKids/index.js
+++ b/FairyTaleKids/index.js
@@ -1,0 +1,5 @@
+import {AppRegistry} from 'react-native';
+import App from './src/App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/FairyTaleKids/package.json
+++ b/FairyTaleKids/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "FairyTaleKids",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "start": "react-native start",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-native": "^0.73.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/FairyTaleKids/src/App.tsx
+++ b/FairyTaleKids/src/App.tsx
@@ -1,0 +1,56 @@
+import React, {useState} from 'react';
+import {SafeAreaView, Text, TextInput, Button, View, ScrollView, StyleSheet} from 'react-native';
+import {personalizeStory} from './stories';
+
+const App = () => {
+  const [name, setName] = useState('');
+  const [age, setAge] = useState('');
+  const [story, setStory] = useState<string[] | null>(null);
+
+  const generate = () => {
+    if (!name || !age) {
+      return;
+    }
+    setStory(personalizeStory(name, age));
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title}>FairyTaleKids</Text>
+        <TextInput
+          placeholder="Çocuk Adı"
+          value={name}
+          onChangeText={setName}
+          style={styles.input}
+        />
+        <TextInput
+          placeholder="Yaşı"
+          value={age}
+          onChangeText={setAge}
+          keyboardType="numeric"
+          style={styles.input}
+        />
+        <Button title="Masalı Oluştur" onPress={generate} />
+        {story && (
+          <View style={styles.storyContainer}>
+            {story.map((p, idx) => (
+              <Text key={idx} style={styles.paragraph}>{p}</Text>
+            ))}
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {flex: 1},
+  content: {padding: 16},
+  title: {fontSize: 24, fontWeight: 'bold', marginBottom: 16},
+  input: {borderWidth: 1, borderColor: '#ccc', padding: 8, marginBottom: 12},
+  storyContainer: {marginTop: 16},
+  paragraph: {marginBottom: 8, fontSize: 16},
+});
+
+export default App;

--- a/FairyTaleKids/src/stories.ts
+++ b/FairyTaleKids/src/stories.ts
@@ -1,0 +1,37 @@
+export const stories: string[][] = [
+  [
+    "Bir varmış bir yokmuş, {age} yaşındaki {name} adında cesur bir çocuk varmış.",
+    "Bir gün {name}, ormanda gizli bir kapı bulmuş.",
+    "Kapı onu renkli bir dünyaya götürmüş ve {name} orada yeni arkadaşlar edinmiş.",
+    "Gün batarken {name} evine dönmüş ve bu macerayı asla unutmamış."
+  ],
+  [
+    "Küçük {name}, {age} yaşında olmasına rağmen yıldızları çok severmiş.",
+    "Bir gece gökyüzüne bakarken kayan bir yıldız görmüş.",
+    "Yıldız, {name}'e dilek hakkı vermiş ve o da dünyayı gezmeyi dilemiş.",
+    "{name}'in dileği gerçek olmuş ve maceralar başlamış."
+  ],
+  [
+    "{age} yaşındaki {name}, köyündeki en iyi uçurtma uçurucusuymuş.",
+    "Rüzgarın güçlü olduğu bir günde uçurtması gökyüzünde dans etmiş.",
+    "Uçurtma, {name}'i bulutların üzerine kadar taşımış.",
+    "Orada bulut prensesiyle tanışıp yeni hikayeler öğrenmiş."
+  ],
+  [
+    "{name}, {age} yaşında küçük bir mucitmiş.",
+    "Evinde yaptığı minik robot bir gün konuşmaya başlamış.",
+    "Robot, {name}'i gizli bir laboratuvara götürmüş.",
+    "Orada ikisi birlikte harika icatlar yapmış."
+  ],
+  [
+    "{age} yaşındaki {name}, denizin altını merak edermiş.",
+    "Bir gün sihirli bir yüzgeç takıp suyun altına dalmış.",
+    "Deniz canlıları {name}'i görünce onu kraliçeleri ilan etmiş.",
+    "{name} bir günlüğüne deniz ülkesini yönetmiş."
+  ]
+];
+
+export function personalizeStory(name: string, age: string): string[] {
+  const story = stories[Math.floor(Math.random() * stories.length)];
+  return story.map(p => p.replace(/\{name\}/g, name).replace(/\{age\}/g, age));
+}

--- a/FairyTaleKids/tsconfig.json
+++ b/FairyTaleKids/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "react",
+    "lib": ["es6"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "target": "esnext",
+    "types": ["react", "react-native"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold FairyTaleKids React Native project with TypeScript configuration
- add story templates and personalization logic for child name and age
- implement UI with inputs for "Çocuk Adı" and "Yaşı" and button to generate story

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68911d2905e0832c8703ef247940cd3b